### PR TITLE
Version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN apk update && \
 RUN wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -O - | tar -xz
 ENV PATH ${PATH}:/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit
 
-COPY --from=alpine/helm:3.9.0 /usr/bin/helm /usr/bin/
+COPY --from=alpine/helm:3.9.4 /usr/bin/helm /usr/bin/

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ stage('Build') {
 
 ## What is installed on this image?
 - Version [3.11.0](https://github.com/openshift/origin/tree/release-3.11) of OKD.
-
+- Version [3.9.4](https://hub.docker.com/layers/alpine/helm/3.9.4/images/sha256-b1883b29f2d04ab86cc4ac052ac8a897fd360e16bbec9dcb37268bcca7d26ed8?context=explore) of Helm.


### PR DESCRIPTION
Resolved [CVE-2022-1996](https://avd.aquasec.com/nvd/2022/cve-2022-1996/) with a Helm version bump.